### PR TITLE
Fix Twitter social card image property name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metathis
 Title: HTML Metadata Tags for 'R Markdown' and 'Shiny'
-Version: 1.0.3
+Version: 1.0.3.9000
 Authors@R: 
     person(given = "Garrick",
            family = "Aden-Buie",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # metathis (development version)
 
+- Fixed an issue with the Twitter image `<meta>` tag (thanks @llrs, #19).
+
 # metathis 1.0.3
 
 - Fixed an issue with open graph social media `<meta>` tags (#10)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# metathis (development version)
+
 # metathis 1.0.3
 
 - Fixed an issue with open graph social media `<meta>` tags (#10)

--- a/R/social.R
+++ b/R/social.R
@@ -84,7 +84,7 @@ meta_social <- function(
     "twitter:title"       = title,
     "twitter:description" = description,
     "twitter:url"         = url,
-    "twitter:image:src"   = image,
+    "twitter:image"       = image,
     "twitter:image:alt"   = image_alt,
     "twitter:image:width" = image_width,
     "twitter:image:height"= image_height,

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/metathis)](https://CRAN.R-project.org/package=metathis)
-[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![travis](https://travis-ci.org/gadenbuie/metathis.svg?branch=master)](https://travis-ci.org/gadenbuie/metathis)
 [![Codecov](https://img.shields.io/codecov/c/github/gadenbuie/metathis)](https://codecov.io/github/gadenbuie/metathis)
 <!-- badges: end -->

--- a/README.Rmd
+++ b/README.Rmd
@@ -51,14 +51,18 @@ If you want great looking social media cards, the [`meta_social()`](http://pkg.g
 You can install the latest version of metathis from [CRAN](https://CRAN.R-project.org) with:
 
 ``` r
+# CRAN
 install.packages("metathis")
 ```
 
-And the development version from [Github](https://github.com/gadenbuie/metathis) with:
+And the development version from [Github](https://github.com/gadenbuie/metathis) or [r-universe](https://gadenbuie.r-universe.dev) with:
 
 ``` r
+# r-universe
+install.packages("metathis", repos = "https://gadenbuie.r-universe.dev")
+
 # install.packages("devtools")
-devtools::install_github("gadenbuie/metathis")
+devtools::install_github("gadenbuie/metathis@main")
 ```
 
 ## Works In

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![CRAN
 status](https://www.r-pkg.org/badges/version/metathis)](https://CRAN.R-project.org/package=metathis)
 [![Lifecycle:
-stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![travis](https://travis-ci.org/gadenbuie/metathis.svg?branch=master)](https://travis-ci.org/gadenbuie/metathis)
 [![Codecov](https://img.shields.io/codecov/c/github/gadenbuie/metathis)](https://codecov.io/github/gadenbuie/metathis)
 <!-- badges: end -->
@@ -122,7 +122,7 @@ meta() %>%
     #> <meta name="twitter:title" content="R for Data Science"/>
     #> <meta name="twitter:description" content="This book will teach you how to do data science with R..."/>
     #> <meta name="twitter:url" content="https://r4ds.had.co.nz"/>
-    #> <meta name="twitter:image:src" content="https://r4ds.had.co.nz/cover.png"/>
+    #> <meta name="twitter:image" content="https://r4ds.had.co.nz/cover.png"/>
     #> <meta name="twitter:image:alt" content="The cover of the R4DS book"/>
     #> <meta name="twitter:card" content="summary"/>
     #> <meta name="twitter:creator" content="@hadley"/>
@@ -166,8 +166,8 @@ ui <- fluidPage(
 
 To use `metathis` in [xaringan](https://slides.yihui.org/xaringan)
 slides, add `meta()` and related tags in a chunk anywhere in your
-slide’s source `.Rmd` file. This example is from a [presentation on
-the drake package](https://pkg.garrickadenbuie.com/drake-intro/).
+slide’s source `.Rmd` file. This example is from a [presentation on the
+drake package](https://pkg.garrickadenbuie.com/drake-intro/).
 
 ```` markdown
 ```{r meta, echo=FALSE}
@@ -207,7 +207,7 @@ Finally, thanks to the [RStudio team](https://github.com/rstudio) and
 others who developed [htmltools](https://github.com/rstudio/htmltools)
 for making HTML in R a breeze.
 
------
+------------------------------------------------------------------------
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,20 @@ You can install the latest version of metathis from
 [CRAN](https://CRAN.R-project.org) with:
 
 ``` r
+# CRAN
 install.packages("metathis")
 ```
 
 And the development version from
-[Github](https://github.com/gadenbuie/metathis) with:
+[Github](https://github.com/gadenbuie/metathis) or
+[r-universe](https://gadenbuie.r-universe.dev) with:
 
 ``` r
+# r-universe
+install.packages("metathis", repos = "https://gadenbuie.r-universe.dev")
+
 # install.packages("devtools")
-devtools::install_github("gadenbuie/metathis")
+devtools::install_github("gadenbuie/metathis@main")
 ```
 
 ## Works In


### PR DESCRIPTION
Fixes #19 by using `name="twitter:image"` instead of `name="twitter:image:src"`.