### PR TITLE
Hotfix v1.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metathis
 Title: HTML Metadata Tags for 'R Markdown' and 'Shiny'
-Version: 1.1.0.9000
+Version: 1.1.1
 Authors@R: 
     person(given = "Garrick",
            family = "Aden-Buie",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metathis
 Title: HTML Metadata Tags for 'R Markdown' and 'Shiny'
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: 
     person(given = "Garrick",
            family = "Aden-Buie",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# metathis (development version)
+
 # metathis 1.1.0
 
 - Fixed an issue with the Twitter image `<meta>` tag (thanks @llrs, #19).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# metathis (development version)
+# metathis 1.1.1
+
+- Fixed an issue that caused metathis to fail for versions of rmarkdown <= 2.8
 
 # metathis 1.1.0
 

--- a/R/meta.R
+++ b/R/meta.R
@@ -210,10 +210,16 @@ prepend_to_meta <- function(.meta, .list = NULL) {
 metaDependency <- function(.meta) {
   assert_is_meta(.meta)
 
+  src <- if (has_package_version("rmarkdown", 2.9)) {
+    c(href = "/")
+  } else {
+    system.file(package = "metathis")
+  }
+
   htmltools::htmlDependency(
     paste0("metathis", "-", random_id()),
     version = metathis_version,
-    src = c(href = "http://example.com"),
+    src = src,
     all_files = FALSE,
     head = .meta %>% paste()
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,20 @@
+# nocov start
+has_package_version <- function(package, version) {
+  pkg_v <- packageVersion(package)
+  if (is.null(pkg_v)) {
+    return(FALSE)
+  }
+  pkg_v >= package_version(version)
+}
+
+packageVersion <- function(package) {
+  if (!requireNamespace(package, quietly = TRUE)) {
+    return(NULL)
+  }
+  pkg_v <- read.dcf(
+    system.file("DESCRIPTION", package = package),
+    fields = "Version"
+  )
+  package_version(pkg_v[[1]])
+}
+# nocov end

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,0 @@
-I'm resubmitting this package with a hot-fix
-for an issue that occurs when this package is
-used with an older version of {rmarkdown}.
-I inadvertently relied on behavior
-introduced in the latest version of rmarkdown (2.9).
-I apologize for missing the issue in testing
-and for the small delay between submissions;
-the issue is large enough to warrant
-an immediate fix.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,9 @@
-This is a re-submission to remove a folder that was included by accident
-and that caused the pre-check to fail.
-
-Original submission notes:
-
-> This is a new submission and a maintenance release
-> with a small number of new features.
+I'm resubmitting this package with a hot-fix
+for an issue that occurs when this package is
+used with an older version of {rmarkdown}.
+I inadvertently relied on behavior
+introduced in the latest version of rmarkdown (2.9).
+I apologize for missing the issue in testing
+and for the small delay between submissions;
+the issue is large enough to warrant
+immediate attention.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -6,4 +6,4 @@ introduced in the latest version of rmarkdown (2.9).
 I apologize for missing the issue in testing
 and for the small delay between submissions;
 the issue is large enough to warrant
-immediate attention.
+an immediate fix.

--- a/tests/testthat/rmd/.gitignore
+++ b/tests/testthat/rmd/.gitignore
@@ -1,0 +1,2 @@
+*html
+*_files

--- a/tests/testthat/rmd/test-not-self-contained.Rmd
+++ b/tests/testthat/rmd/test-not-self-contained.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "test-metathis-not-self-contained-rmd"
 output: 
-  html_document_base:
-    self_contained: false
+  html_document:
+    self_contained: no
 ---
 
 ```{r setup, include=FALSE}

--- a/tests/testthat/test-rmd.R
+++ b/tests/testthat/test-rmd.R
@@ -17,6 +17,7 @@ test_that("knit_print() and include_meta() work in Rmd", {
 
 test_that("Doesn't create empty directory for non self-contained RMarkdown", {
   skip_if_not(rmarkdown::pandoc_available("1.12.3"))
+  skip_if_not(has_package_version("rmarkdown", "2.9"))
 
   temp_dir <- tempfile("metathis-rmd")
   dir.create(temp_dir)

--- a/tests/testthat/test-rmd.R
+++ b/tests/testthat/test-rmd.R
@@ -17,7 +17,6 @@ test_that("knit_print() and include_meta() work in Rmd", {
 
 test_that("Doesn't create empty directory for non self-contained RMarkdown", {
   skip_if_not(rmarkdown::pandoc_available("1.12.3"))
-  skip_if_not(has_package_version("rmarkdown", "2.9"))
 
   temp_dir <- tempfile("metathis-rmd")
   dir.create(temp_dir)
@@ -26,13 +25,14 @@ test_that("Doesn't create empty directory for non self-contained RMarkdown", {
   test_rmd_src <- test_path("rmd", "test-not-self-contained.Rmd")
   test_rmd <- file.path(temp_dir, "test.Rmd")
   file.copy(test_rmd_src, test_rmd)
-  rmarkdown::render(test_rmd, quiet = TRUE)
+  expect_silent(rmarkdown::render(test_rmd, quiet = TRUE))
   out <- readLines(file.path(temp_dir, "test.html"))
 
   has_string <- function(str, n = 1L) {
     sum(grepl(str, out, fixed = FALSE)) == n
   }
 
+  skip_if_not(has_package_version("rmarkdown", "2.9"))
   expect_true(has_string('<meta method="KNIT_PRINT" ?/?>'))
   expect_true(has_string('<meta method="knit_print\\(2\\)" ?/?>'))
   expect_true(has_string('<meta method="INCLUDE_META\\(\\)" ?/?>'))


### PR DESCRIPTION
Prior to `rmarkdown` 2.9, dependencies with only `href` sources cause errors.