### PR TITLE
fix: use pluck_depth when purrr >= 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     htmltools,
     knitr,
     magrittr,
-    purrr
+    purrr (>= 1.0.0)
 Suggests: 
     rmarkdown,
     shiny,

--- a/R/utils-meta.R
+++ b/R/utils-meta.R
@@ -27,11 +27,7 @@ names_replace_underscore <- function(.list, replace = "-") {
 }
 
 duplicate_vector_entries <- function(.list) {
-  if (utils::packageVersion("purrr") >= "1.0.0") {
-    levels <- purrr::map_dbl(.list, purrr::pluck_depth)
-  } else {
-    levels <- purrr::map_dbl(.list, purrr::vec_depth)
-  }
+  levels <- purrr::map_dbl(.list, purrr::pluck_depth)
 
   if (!any(levels > 1)) {
     return(.list)

--- a/R/utils-meta.R
+++ b/R/utils-meta.R
@@ -27,7 +27,11 @@ names_replace_underscore <- function(.list, replace = "-") {
 }
 
 duplicate_vector_entries <- function(.list) {
-  levels <- purrr::map_dbl(.list, purrr::vec_depth)
+  if (utils::packageVersion("purrr") >= "1.0.0") {
+    levels <- purrr::map_dbl(.list, purrr::pluck_depth)
+  } else {
+    levels <- purrr::map_dbl(.list, purrr::vec_depth)
+  }
 
   if (!any(levels > 1)) {
     return(.list)


### PR DESCRIPTION
Closes #35 